### PR TITLE
CI: Cache pip dependencies

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,6 +16,14 @@ jobs:
       with:
         python-version: "3.12"
 
+    - name: Cache pip dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Pipの依存関係をキャッシュするようにGitHub Actionsのワークフローを更新しました。これによりCIの実行時間が短縮されることが期待されます。